### PR TITLE
Added support for recursive copying from output\ directory in package.

### DIFF
--- a/Baseclass.Contrib.Nuget.Output/build/net40/Baseclass.Contrib.Nuget.Output.targets
+++ b/Baseclass.Contrib.Nuget.Output/build/net40/Baseclass.Contrib.Nuget.Output.targets
@@ -21,12 +21,12 @@
 		</XmlPeek>
 		
 		<ItemGroup>
-			<FilesToCopy Include="%(NuSpecFiles.RelativeDir)\output\*.*" />
+			<FilesToCopy Include="%(NuSpecFiles.RelativeDir)\output\**\*.*" />
 		</ItemGroup>
 		
 		<Copy
 				SourceFiles="@(FilesToCopy)"
-				DestinationFolder="$(OutputPath)"
+        DestinationFiles="@(FilesToCopy->'$(OutputPath)\%(RecursiveDir)%(Filename)%(Extension)')"
 				Condition="'@(Peeked->GetType())' == 'System.String'"
 			 />			
 		


### PR DESCRIPTION
This change allows for creation of directory subtrees inside the output folder. 

Example:

``` XML
<file src="output\NugetToOutputFolder.dll" target="output\NugetToOutputFolder.dll" />
<file src="output\SecondOutputFolder.dll" target="output\test\2nd.dll"/>
<file src="Third\bin\Debug\Third.dll" target="output\3rdtest\deeper-recursive\3rd.dll"/>
```

Output directory:

```
bin
 |- Debug
       |- NugetToOutputFolder.dll
       |- test
       |    |- 2nd.dll
       |- 3rdtest
               |- deeper-recursive
                               |- 3rd.dll
```
