### PR TITLE
Fix compilation error CS0103 in UsingTask 'UnzipNuspec'

### DIFF
--- a/Baseclass.Contrib.Nuget.Output/build/net40/Baseclass.Contrib.Nuget.Output.targets
+++ b/Baseclass.Contrib.Nuget.Output/build/net40/Baseclass.Contrib.Nuget.Output.targets
@@ -81,6 +81,7 @@
 			<Reference Include="WindowsBase" />
 			<Using Namespace="System.IO" />
 			<Using Namespace="System.IO.Packaging" />
+			<Using Namespace="System.Threading" />
 			<Code Type="Fragment" Language="cs">      
 				<![CDATA[                
 			var nupkgpath = Path.GetDirectoryName(Nupkg);


### PR DESCRIPTION
After adding Contrib.Nuget (as an dependency of SFML.Net) to my project, it failed to compile with error CS0103: "The name 'Thread' does not exist in current context."

I fixed the problem by 'using' namespace 'System.Threading' in UsingTask 'UnzipNuspec'.

My environment: Visual Studio Professional 2012, $(MSBuildToolsVersion) is '4.0'.
