### PR TITLE
Add support of TFS published website

### DIFF
--- a/Baseclass.Contrib.Nuget.Output/Baseclass.Contrib.Nuget.Output.Web.nuspec
+++ b/Baseclass.Contrib.Nuget.Output/Baseclass.Contrib.Nuget.Output.Web.nuspec
@@ -10,10 +10,10 @@
 		<projectUrl>http://www.baseclass.ch/Contrib/Nuget</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Adds msdeploy/publish support to Baseclass.Contrib.Nuget.Output.</description>
-		<releaseNotes>- Supports msdeploy and publish</releaseNotes>
+		<releaseNotes>- Supports msdeploy and publish even through TFS with UseWPP_CopyWebApplication to true</releaseNotes>
 		<tags>Nuget Targets Copy Output build package convention web publish msdeploy</tags>
 		<dependencies>
-			<dependency id="Baseclass.Contrib.Nuget.Output" version="1.0.4" />
+			<dependency id="Baseclass.Contrib.Nuget.Output" version="1.0.7" />
 		</dependencies>
     </metadata>
     <files>

--- a/Baseclass.Contrib.Nuget.Output/build/net40/Baseclass.Contrib.Nuget.Output.Web.targets
+++ b/Baseclass.Contrib.Nuget.Output/build/net40/Baseclass.Contrib.Nuget.Output.Web.targets
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<CopyAllFilesToSingleFolderForPackageDependsOn>
+		<PipelineCollectFilesPhaseDependsOn>
+		$(PipelineCollectFilesPhaseDependsOn);
 		CollectNugetPackageFiles;
-		$(CopyAllFilesToSingleFolderForPackageDependsOn);
-		</CopyAllFilesToSingleFolderForPackageDependsOn>
+		</PipelineCollectFilesPhaseDependsOn>
 	</PropertyGroup>
 	<Target Inputs="@(NupkgFiles)" Outputs="%(Identity).Dummy" Name="CollectNugetPackageFiles">
 	    <Message Text="Collecting files for publication for %(NupkgFiles.Filename):" />

--- a/CreatePackages.bat
+++ b/CreatePackages.bat
@@ -1,6 +1,6 @@
 .nuget\nuget.exe pack Baseclass.Contrib.Nuget.Output\Baseclass.Contrib.Nuget.Output.nuspec -Version 1.0.7
 
-.nuget\nuget.exe pack Baseclass.Contrib.Nuget.Output\Baseclass.Contrib.Nuget.Output.Web.nuspec -Version 1.0.0
+.nuget\nuget.exe pack Baseclass.Contrib.Nuget.Output\Baseclass.Contrib.Nuget.Output.Web.nuspec -Version 1.0.1
 
 .nuget\nuget.exe pack Baseclass.Contrib.Nuget.Linked\Baseclass.Contrib.Nuget.Linked.nuspec -Version 1.0.2
 


### PR DESCRIPTION
when building with TFS $(OutDir) property is redirected and web application are output in a _PublishedWebsites folder (see Microsoft.WebApplication.targets for more details)

In this case if UseWPP_CopyWebApplication is set to true, then the copy of web application will use the publish pipeline

But instead of using the CopyAllFilesToSingleFolderForPackage target it will use the _WPPCopyWebApplication target. Both are very similar but it's essentially a question of ouput location.

Extending PipelineCollectFilesPhaseDependsOn target instead of CopyAllFilesToSingleFolderForPackageDependsOn allow to be independent of all of those considerations because it's the main target for collecting files that is common to all other paths (publish with CopyAllFilesToSingleFolderForPackage or with _WPPCopyWebApplication)