### PR TITLE
Fixes "Path too long" issues

### DIFF
--- a/Baseclass.Contrib.Nuget.Output/build/net40/Baseclass.Contrib.Nuget.Output.targets
+++ b/Baseclass.Contrib.Nuget.Output/build/net40/Baseclass.Contrib.Nuget.Output.targets
@@ -20,8 +20,12 @@
 			<Output TaskParameter="Result" ItemName="Peeked" />
 		</XmlPeek>
 
+		<PropertyGroup>
+			<FullPaths>$([System.IO.Path]::GetFullPath(%(NupkgFiles.RelativeDir)))</FullPaths>
+		</PropertyGroup>
+
 		<ItemGroup>
-			<FilesToCopy Include="%(NupkgFiles.RelativeDir)\output\**\*.*" />
+			<FilesToCopy Include="$(FullPaths)\output\**\*.*" />
 		</ItemGroup>
 
 		<Copy


### PR DESCRIPTION
The MSBuild "Copy" task doesn't resolves relative path before using them. Because of this, paths copied by Contrib.Nuget.Output can only be 210 characters long instead of 260, since paths are taken relative to the
Contrib.Nuget.Output package (Baseclass.Contrib.Nuget.Ouput.1.0.0\build\net40\..\..\..\).
Resolving the relative paths before passing them to the Copy task resolves the issue.