### PR TITLE
Fix concurrency issue regression

### DIFF
--- a/Baseclass.Contrib.Nuget.Output/Baseclass.Contrib.Nuget.Output.Build/NugetPackageManager.cs
+++ b/Baseclass.Contrib.Nuget.Output/Baseclass.Contrib.Nuget.Output.Build/NugetPackageManager.cs
@@ -72,40 +72,40 @@ namespace Baseclass.Contrib.Nuget.Output.Build
 
                     // use a mutex to ensure that only one process unzip the nuspec
                     // and that one process do not start reading it due to its existence while another one is still writing it.
-                    if (!File.Exists(nugetSpec))
+                    var mut = new Mutex(false, nugetSpec);
+                    var xml = new XmlDocument();
+                    try
                     {
-                        var mut = new Mutex(false, "UnzipNuSpec");
-                        try
-                        {
-                            mut.WaitOne();
+                        mut.WaitOne();
 
-                            if (!File.Exists(nugetSpec))
-                                try
+                        if (!File.Exists(nugetSpec))
+                        {
+                            try
+                            {
+                                using (
+                                    var outputstream = new FileStream(nugetSpec, FileMode.Create,
+                                        FileAccess.ReadWrite, FileShare.None))
                                 {
-                                    using (
-                                        var outputstream = new FileStream(nugetSpec, FileMode.Create,
-                                            FileAccess.ReadWrite, FileShare.None))
+                                    using (var nspecstream = nuspec.GetStream())
                                     {
-                                        using (var nspecstream = nuspec.GetStream())
-                                        {
-                                            nspecstream.CopyTo(outputstream);
-                                        }
+                                        nspecstream.CopyTo(outputstream);
                                     }
                                 }
-                                catch (IOException)
-                                {
-                                    if (!File.Exists(nugetSpec))
-                                        throw;
-                                }
+                            }
+                            catch (IOException)
+                            {
+                                if (!File.Exists(nugetSpec))
+                                    throw;
+                            }
                         }
-                        finally
-                        {
-                            mut.ReleaseMutex();
-                        }
-                    }
 
-                    var xml = new XmlDocument();
-                    xml.LoadXml(File.ReadAllText(nugetSpec));
+                        xml.Load(nugetSpec);
+                    }
+                    finally
+                    {
+                        mut.ReleaseMutex();
+                    }
+                    
                     var deps = xml.GetElementsByTagName("dependency");
                     foreach (XmlNode dep in deps)
                     {

--- a/Baseclass.Contrib.Nuget.Output/Baseclass.Contrib.Nuget.Output.Build/NugetPackageManager.cs
+++ b/Baseclass.Contrib.Nuget.Output/Baseclass.Contrib.Nuget.Output.Build/NugetPackageManager.cs
@@ -68,11 +68,12 @@ namespace Baseclass.Contrib.Nuget.Output.Build
                 using (var archive = Package.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read))
                 {
                     var nuspec = archive.GetParts().Single(part => part.Uri.ToString().EndsWith(".nuspec"));
-                    var nugetSpec = Path.Combine(nupkgpath, Path.GetFileName(nuspec.Uri.ToString()));
+                    var nuspecFilename = Path.GetFileName(nuspec.Uri.ToString());
+                    var nugetSpec = Path.Combine(nupkgpath, nuspecFilename);
 
                     // use a mutex to ensure that only one process unzip the nuspec
                     // and that one process do not start reading it due to its existence while another one is still writing it.
-                    var mut = new Mutex(false, nugetSpec);
+                    var mut = new Mutex(false, nuspecFilename);
                     var xml = new XmlDocument();
                     try
                     {

--- a/Baseclass.Contrib.Nuget.Output/Baseclass.Contrib.Nuget.Output.nuspec
+++ b/Baseclass.Contrib.Nuget.Output/Baseclass.Contrib.Nuget.Output.nuspec
@@ -10,8 +10,8 @@
         <projectUrl>http://www.baseclass.ch/Contrib/Nuget</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Treats the "output" folder in an dependend nuget package as an additional special folder and copies it's content to the build folder</description>
-		<releaseNotes xml:space="preserve">- Added support for paket
-- Added support for repository path configuration</releaseNotes>
+		<releaseNotes xml:space="preserve">- Fix concurrency issue regression
+- Reduce scope of the mutex to optimize parallel compilations</releaseNotes>
         <tags>Nuget Targets Copy Output build package convention</tags>
     </metadata>
     <files>


### PR DESCRIPTION
We recently upgrade Baseclass.Contrib.Nuget.Output package to support VS2017

However we discover that recent versions have a concurrency issue similar to the one I had fixed in the past.  
Looking at the code it appears that a regression appear when the c# code has been moved from the targets file to a cs file in the c# project.  
The mutex do not cover any more the read file operation but only the file extraction operation which cause concurrency issue when one try to read the file while one is currently extracting it which sometimes occurs on our build servers in CI.

The intend of this pull request is to fix that regression by re-introduce the file read operation inside the mutex.

I've also include the idea of issue #36 to improve performances in a concurrent build environment.

This is now running fine on our build servers with an internal pre-release package.