### PR TITLE
Use environmnet dependent directory separator instead of hard coded for windows only

### DIFF
--- a/Baseclass.Contrib.Nuget.Output/Baseclass.Contrib.Nuget.Output.Build/NugetPackageManager.cs
+++ b/Baseclass.Contrib.Nuget.Output/Baseclass.Contrib.Nuget.Output.Build/NugetPackageManager.cs
@@ -139,7 +139,7 @@ namespace Baseclass.Contrib.Nuget.Output.Build
                     packagesPath = Environment.GetEnvironmentVariable("NUGET_PACKAGES") ??
                                    Path.Combine(
                                        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                                       @".nuget\packages");
+                                       ".nuget" + Path.DirectorySeparatorChar + "packages");
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(currentNugetPackageSource), currentNugetPackageSource,


### PR DESCRIPTION
Use environmnet dependent directory separator instead of hard coded for windows only