### PR TITLE
Update information for nuspec files 

### DIFF
--- a/Baseclass.Contrib.Nuget.GitIgnoreContent/Baseclass.Contrib.Nuget.GitIgnoreContent.nuspec
+++ b/Baseclass.Contrib.Nuget.GitIgnoreContent/Baseclass.Contrib.Nuget.GitIgnoreContent.nuspec
@@ -6,20 +6,20 @@
         <title>Baseclass.Contrib.Nuget.GitIgnoreContent</title>
         <authors>Daniel Romero</authors>
         <owners>baseclass</owners>
-		<licenseUrl>http://www.baseclass.ch/documents/MITLicense.txt</licenseUrl>
-		<projectUrl>http://www.baseclass.ch/Contrib/Nuget</projectUrl>
+        <license type="expression">MIT</license>
+        <projectUrl>https://github.com/baseclass/Contrib.Nuget</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<summary>Ignore nuget content files in git</summary>
+        <summary>Ignore nuget content files in git</summary>
         <description>Ignore nuget content files in git:
 			- Generate entries in the .gitignore file to exclude nuget content files from the source repository
 			- Restore nuget content files before building (Automatically in VS and manually with a powershell script
 			- Use Initialize-GitIgnore to add it to an existing solution</description>
-		<tags>Nuget Content Files Git Ignore GitIgnore</tags>
+        <tags>Nuget Content Files Git Ignore GitIgnore</tags>
     </metadata>
     <files>
-		<file src="tools\init.ps1" target="tools\init.ps1" />
-		<file src="tools\Baseclass.Contrib.Nuget.GitIgnoreContent.psm1" target="tools\Baseclass.Contrib.Nuget.GitIgnoreContent.psm1" />
-		<file src="tools\GitIgnoreNugetContentRegisterEvents.ps1" target="tools\GitIgnoreNugetContentRegisterEvents.ps1" />
-		<file src="tools\RestoreNugetContent.ps1" target="tools\RestoreNugetContent.ps1" />
+        <file src="tools\init.ps1" target="tools\init.ps1" />
+        <file src="tools\Baseclass.Contrib.Nuget.GitIgnoreContent.psm1" target="tools\Baseclass.Contrib.Nuget.GitIgnoreContent.psm1" />
+        <file src="tools\GitIgnoreNugetContentRegisterEvents.ps1" target="tools\GitIgnoreNugetContentRegisterEvents.ps1" />
+        <file src="tools\RestoreNugetContent.ps1" target="tools\RestoreNugetContent.ps1" />
     </files>
 </package>

--- a/Baseclass.Contrib.Nuget.Output/Baseclass.Contrib.Nuget.Output.Web.nuspec
+++ b/Baseclass.Contrib.Nuget.Output/Baseclass.Contrib.Nuget.Output.Web.nuspec
@@ -6,8 +6,8 @@
         <title>[Obsolete] Baseclass.Contrib.Nuget.Output.Web</title>
         <authors>Daniel Romero</authors>
         <owners>baseclass</owners>
-        <licenseUrl>http://www.baseclass.ch/documents/MITLicense.txt</licenseUrl>
-        <projectUrl>http://www.baseclass.ch/Contrib/Nuget</projectUrl>
+        <license type="expression">MIT</license>
+        <projectUrl>https://github.com/baseclass/Contrib.Nuget</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>[Obsolete] now included in Baseclass.Contrib.Nuget.Output</description>
         <releaseNotes>This package can be safely removed. It just help you to upgrade to Baseclass.Contrib.Nuget.Output 2.0.0</releaseNotes>

--- a/Baseclass.Contrib.Nuget.Output/Baseclass.Contrib.Nuget.Output.nuspec
+++ b/Baseclass.Contrib.Nuget.Output/Baseclass.Contrib.Nuget.Output.nuspec
@@ -6,11 +6,11 @@
         <title>Baseclass.Contrib.Nuget.Output</title>
         <authors>Daniel Romero</authors>
         <owners>baseclass</owners>
-        <licenseUrl>http://www.baseclass.ch/documents/MITLicense.txt</licenseUrl>
-        <projectUrl>http://www.baseclass.ch/Contrib/Nuget</projectUrl>
+        <license type="expression">MIT</license>
+        <projectUrl>https://github.com/baseclass/Contrib.Nuget</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Treats the "output" folder in an dependend nuget package as an additional special folder and copies it's content to the build folder</description>
-		<releaseNotes xml:space="preserve">- Use TaskHostFactory to fix locking of package folder</releaseNotes>
+        <releaseNotes xml:space="preserve">- Use TaskHostFactory to fix locking of package folder</releaseNotes>
         <tags>Nuget Targets Copy Output build package convention</tags>
     </metadata>
     <files>


### PR DESCRIPTION
- Exchanged the no longer accessible URL to baseclass.ch with the github.com address 
- Exchanged the deprecated license url tag with the license tag. Used with type expression and select the MIT license.
To avoid that the no longer accessible baseclass.ch website is a problem.
- Exchanged some tabs used with whitespace to unified the view to it.